### PR TITLE
firmadyne.config: Fixing logic of check_arch

### DIFF
--- a/firmadyne.config
+++ b/firmadyne.config
@@ -12,28 +12,28 @@ SCRIPT_DIR=${FIRMWARE_DIR}/scripts/
 # functions to safely compute other paths
 
 check_arch () {
-    ARCHS=("armel", "mipseb", "mipsel")
+    ARCHS=("armel" "mipseb" "mipsel")
 
     if [ -z "${1}" ]; then
-        return 1
+        return 0
     fi
 
     match=0
     for i in "${ARCHS[@]}"; do
-        if [[ "${1}" == "$i" ]]; then
+        if [ "${1}" == "$i" ]; then
             match=1
         fi
     done
 
-    if [[ ${match} -eq 0 ]]; then
-        return 1
+    if [ "${match}" -eq 0 ]; then
+        return 0
     fi
 
-    return 0
+    return 1
 }
 
 check_number () {
-    if [[ ${1} -ge 0 ]]; then
+    if [ "${1}" -ge 0 ]; then
         return 1
     fi
 
@@ -41,7 +41,7 @@ check_number () {
 }
 
 check_root () {
-    if [[ ${EUID} -eq 0 ]]; then
+    if [ "${EUID}" -eq 0 ]; then
         return 1
     fi
 

--- a/scripts/inferNetwork.sh
+++ b/scripts/inferNetwork.sh
@@ -19,7 +19,7 @@ fi
 IID=${1}
 
 if [ $# -gt 1 ]; then
-    if [ check_arch ${2} -eq 1 ]; then
+    if check_arch "${2}"; then
         echo "Error: Invalid architecture!"
         exit 1
     fi

--- a/scripts/makeImage.sh
+++ b/scripts/makeImage.sh
@@ -24,7 +24,7 @@ if check_root; then
 fi
 
 if [ $# -gt 1 ]; then
-    if [ check_arch ${2} -eq 1 ]; then
+    if check_arch "${2}"; then
         echo "Error: Invalid architecture!"
         exit 1
     fi

--- a/scripts/run-debug.sh
+++ b/scripts/run-debug.sh
@@ -19,7 +19,7 @@ fi
 IID=${1}
 
 if [ $# -gt 1 ]; then
-    if [ check_arch ${2} -eq 1 ]; then
+    if check_arch "${2}"; then
         echo "Error: Invalid architecture!"
         exit 1
     fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -19,7 +19,7 @@ fi
 IID=${1}
 
 if [ $# -gt 1 ]; then
-    if [ check_arch ${2} -eq 1 ]; then
+    if check_arch "${2}"; then
         echo "Error: Invalid architecture!"
         exit 1
     fi


### PR DESCRIPTION
1) The $ARCHS array should not have commas in it

2) The uses of check_arch() outside firmadyne.config have inverted logic that is incorrect