### PR TITLE
resolve links before creating files in /etc

### DIFF
--- a/scripts/fixImage.sh
+++ b/scripts/fixImage.sh
@@ -16,16 +16,19 @@ resolve_link() {
 mkdir -p $(resolve_link /etc)
 if [ ! -s /etc/TZ ]; then
     echo "Creating /etc/TZ!"
+    mkdir -p "$(dirname $(resolve_link /etc/TZ))"
     echo "EST5EDT" > $(resolve_link /etc/TZ)
 fi
 
 if [ ! -s /etc/hosts ]; then
     echo "Creating /etc/hosts!"
+    mkdir -p "$(dirname $(resolve_link /etc/hosts))"
     echo "127.0.0.1 localhost" > $(resolve_link /etc/hosts)
 fi
 
 if [ ! -s /etc/passwd ]; then
     echo "Creating /etc/passwd!"
+    mkdir -p "$(dirname $(resolve_link /etc/passwd))"
     echo "root::0:0:root:/root:/bin/sh" > $(resolve_link /etc/passwd)
 fi
 

--- a/scripts/fixImage.sh
+++ b/scripts/fixImage.sh
@@ -13,28 +13,28 @@ resolve_link() {
 }
 
 # make /etc and add some essential files
-mkdir -p $(resolve_link /etc)
+mkdir -p "$(resolve_link /etc)"
 if [ ! -s /etc/TZ ]; then
     echo "Creating /etc/TZ!"
     mkdir -p "$(dirname $(resolve_link /etc/TZ))"
-    echo "EST5EDT" > $(resolve_link /etc/TZ)
+    echo "EST5EDT" > "$(resolve_link /etc/TZ)"
 fi
 
 if [ ! -s /etc/hosts ]; then
     echo "Creating /etc/hosts!"
     mkdir -p "$(dirname $(resolve_link /etc/hosts))"
-    echo "127.0.0.1 localhost" > $(resolve_link /etc/hosts)
+    echo "127.0.0.1 localhost" > "$(resolve_link /etc/hosts)"
 fi
 
 if [ ! -s /etc/passwd ]; then
     echo "Creating /etc/passwd!"
     mkdir -p "$(dirname $(resolve_link /etc/passwd))"
-    echo "root::0:0:root:/root:/bin/sh" > $(resolve_link /etc/passwd)
+    echo "root::0:0:root:/root:/bin/sh" > "$(resolve_link /etc/passwd)"
 fi
 
 # make /dev and add default device nodes if current /dev does not have greater
 # than 5 device nodes
-mkdir -p $(resolve_link /dev)
+mkdir -p "$(resolve_link /dev)"
 FILECOUNT="$($BUSYBOX find ${WORKDIR}/dev -maxdepth 1 -type b -o -type c -print | $BUSYBOX wc -l)"
 if [ $FILECOUNT -lt "5" ]; then
     echo "Warning: Recreating device nodes!"

--- a/scripts/fixImage.sh
+++ b/scripts/fixImage.sh
@@ -5,28 +5,28 @@ BUSYBOX="/busybox"
 
 # print input if not symlink, otherwise attempt to resolve symlink
 resolve_link() {
-    DIR=$($BUSYBOX readlink $1)
-    if [ -z "$DIR" ]; then
+    TARGET=$($BUSYBOX readlink $1)
+    if [ -z "$TARGET" ]; then
         echo "$1"
     fi
-    echo "$DIR"
+    echo "$TARGET"
 }
 
 # make /etc and add some essential files
 mkdir -p $(resolve_link /etc)
 if [ ! -s /etc/TZ ]; then
     echo "Creating /etc/TZ!"
-    echo "EST5EDT" > /etc/TZ
+    echo "EST5EDT" > $(resolve_link /etc/TZ)
 fi
 
 if [ ! -s /etc/hosts ]; then
     echo "Creating /etc/hosts!"
-    echo "127.0.0.1 localhost" > /etc/hosts
+    echo "127.0.0.1 localhost" > $(resolve_link /etc/hosts)
 fi
 
 if [ ! -s /etc/passwd ]; then
     echo "Creating /etc/passwd!"
-    echo "root::0:0:root:/root:/bin/sh" > /etc/passwd
+    echo "root::0:0:root:/root:/bin/sh" > $(resolve_link /etc/passwd)
 fi
 
 # make /dev and add default device nodes if current /dev does not have greater


### PR DESCRIPTION
In some cases, the files may be soft links to a nonexistent place, say /tmp/config/passwd, which is the cause of the kind of errors "can't create /etc/passwd: nonexistent directory".