### PR TITLE
fixed getArch.sh return '' bug && add one more search directory

### DIFF
--- a/scripts/getArch.sh
+++ b/scripts/getArch.sh
@@ -57,8 +57,12 @@ IID=${BASE%.tar.gz}
 
 mkdir -p "/tmp/${IID}"
 
+set +e
 FILES="$(tar -tf $INFILE | grep -e "/busybox\$") "
 FILES+="$(tar -tf $INFILE | grep -E "/sbin/[[:alpha:]]+")"
+FILES+="$(tar -tf $INFILE | grep -E "/bin/[[:alpha:]]+")"
+set -e
+
 for TARGET in ${FILES}
 do
     SKIP=$(echo "${TARGET}" | fgrep -o / | wc -l)


### PR DESCRIPTION
refer to issue #72 

1. getArch.sh won't stop immediately when no such pattern in string to be `grep`. 

2. add one more directory `/bin`, which may also exist with a high probability. 