### PR TITLE
bugfix for #89 issue

### DIFF
--- a/firmadyne.config
+++ b/firmadyne.config
@@ -182,5 +182,5 @@ get_scratch () {
 }
 
 get_device () {
-    echo "/dev/mapper/loop0p1"
+    echo "/dev/mapper/$1"
 }

--- a/firmadyne.config
+++ b/firmadyne.config
@@ -182,5 +182,6 @@ get_scratch () {
 }
 
 get_device () {
-    echo "/dev/mapper/$1"
+    # Parses output from kpartx
+    echo "/dev/mapper/$(echo $1 | cut -d ' ' -f 3)"
 }

--- a/scripts/makeImage.sh
+++ b/scripts/makeImage.sh
@@ -15,7 +15,6 @@ if check_number $1; then
     echo "Usage: makeImage.sh <image ID> [<architecture]"
     exit 1
 fi
-
 IID=${1}
 
 if check_root; then
@@ -48,8 +47,6 @@ IMAGE_DIR=`get_fs_mount ${IID}`
 CONSOLE=`get_console ${ARCH}`
 LIBNVRAM=`get_nvram ${ARCH}`
 
-#DEVICE=`get_device`
-
 echo "----Copying Filesystem Tarball----"
 mkdir -p "${WORK_DIR}"
 chmod a+rwx "${WORK_DIR}"
@@ -73,9 +70,7 @@ echo "----Creating Partition Table----"
 echo -e "o\nn\np\n1\n\n\nw" | /sbin/fdisk "${IMAGE}"
 
 echo "----Mounting QEMU Image----"
-output=$(kpartx -a -s -v "${IMAGE}")
-foo=$(echo "$output" | cut -d ' ' -f 3)
-DEVICE=`get_device "${foo}"`
+DEVICE=$(get_device "$(kpartx -a -s -v "${IMAGE}")")
 sleep 1
 
 echo "----Creating Filesystem----"

--- a/scripts/makeImage.sh
+++ b/scripts/makeImage.sh
@@ -73,7 +73,9 @@ echo "----Creating Partition Table----"
 echo -e "o\nn\np\n1\n\n\nw" | /sbin/fdisk "${IMAGE}"
 
 echo "----Mounting QEMU Image----"
-kpartx -a -s -v "${IMAGE}"
+output=$(kpartx -a -s -v "${IMAGE}")
+foo=$(echo "$output" | cut -d ' ' -f 3)
+DEVICE="/dev/mapper/$foo"
 sleep 1
 
 echo "----Creating Filesystem----"

--- a/scripts/makeImage.sh
+++ b/scripts/makeImage.sh
@@ -11,11 +11,11 @@ else
     echo "Error: Could not find 'firmadyne.config'!"
     exit 1
 fi
-
 if check_number $1; then
     echo "Usage: makeImage.sh <image ID> [<architecture]"
     exit 1
 fi
+
 IID=${1}
 
 if check_root; then
@@ -48,7 +48,7 @@ IMAGE_DIR=`get_fs_mount ${IID}`
 CONSOLE=`get_console ${ARCH}`
 LIBNVRAM=`get_nvram ${ARCH}`
 
-DEVICE=`get_device`
+#DEVICE=`get_device`
 
 echo "----Copying Filesystem Tarball----"
 mkdir -p "${WORK_DIR}"
@@ -75,7 +75,7 @@ echo -e "o\nn\np\n1\n\n\nw" | /sbin/fdisk "${IMAGE}"
 echo "----Mounting QEMU Image----"
 output=$(kpartx -a -s -v "${IMAGE}")
 foo=$(echo "$output" | cut -d ' ' -f 3)
-DEVICE="/dev/mapper/$foo"
+DEVICE=`get_device "${foo}"`
 sleep 1
 
 echo "----Creating Filesystem----"

--- a/scripts/makeImage.sh
+++ b/scripts/makeImage.sh
@@ -11,6 +11,7 @@ else
     echo "Error: Could not find 'firmadyne.config'!"
     exit 1
 fi
+
 if check_number $1; then
     echo "Usage: makeImage.sh <image ID> [<architecture]"
     exit 1

--- a/scripts/mount.sh
+++ b/scripts/mount.sh
@@ -28,11 +28,13 @@ WORK_DIR=`get_scratch ${IID}`
 IMAGE=`get_fs ${IID}`
 IMAGE_DIR=`get_fs_mount ${IID}`
 
-DEVICE=`get_device`
+#DEVICE=`get_device`
 
 echo "----Adding Device File----"
 #/usr/bin/qemu-nbd --connect=/dev/${NBD} "${IMAGE}"
-kpartx -a -s -v "${IMAGE}"
+output=$(kpartx -a -s -v "${IMAGE}")
+foo=$(echo "$output" | cut -d ' ' -f 3)
+DEVICE=`get_device "${foo}"`
 sleep 1
 
 echo "----Making image directory----"

--- a/scripts/mount.sh
+++ b/scripts/mount.sh
@@ -28,13 +28,8 @@ WORK_DIR=`get_scratch ${IID}`
 IMAGE=`get_fs ${IID}`
 IMAGE_DIR=`get_fs_mount ${IID}`
 
-#DEVICE=`get_device`
-
 echo "----Adding Device File----"
-#/usr/bin/qemu-nbd --connect=/dev/${NBD} "${IMAGE}"
-output=$(kpartx -a -s -v "${IMAGE}")
-foo=$(echo "$output" | cut -d ' ' -f 3)
-DEVICE=`get_device "${foo}"`
+DEVICE=$(get_device "$(kpartx -a -s -v "${IMAGE}")")
 sleep 1
 
 echo "----Making image directory----"


### PR DESCRIPTION
As suggested from @ddcc, I have changed the `get_device` function inside `firmadyne.config` and updated the calling method inside other scripts. 
Please note that `unmount.sh` is still unpatched and this solution is only a workaround, imho the best solution could be split into two different functions the `get_device` functionality: 
- a `set_device` that takes as argument `kpartx` output and set a global DEVICE variable 
- a `get_device` that return the previously set value of DEVICE.