### PR TITLE
Add a basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# docker build -t firmadyne .
+FROM ubuntu:14.04
+
+# Update packages
+RUN apt-get update && apt-get upgrade -y && apt-get install -y sudo
+
+# Create firmadyne user
+RUN useradd -m firmadyne
+RUN echo "firmadyne:firmadyne" | chpasswd && adduser firmadyne sudo
+
+# Run setup script
+ADD setup.sh /tmp/setup.sh
+RUN /tmp/setup.sh
+ADD startup.sh /firmadyne/startup.sh
+
+USER firmadyne
+ENTRYPOINT ["/firmadyne/startup.sh"]
+CMD ["/bin/bash"]

--- a/example_analysis.sh
+++ b/example_analysis.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# How to run:
+#    $ docker run --privileged --rm -v $PWD:/work -w /work -it --net=host firmadyne
+#    $ /work/example_analysis.sh
+
+set -e
+set -x
+
+# Download firmware image
+pushd /firmadyne/firmadyne
+wget http://www.downloads.netgear.com/files/GDC/WNAP320/WNAP320%20Firmware%20Version%202.0.3.zip
+ZIP_FILE="WNAP320 Firmware Version 2.0.3.zip"
+
+python3 ./sources/extractor/extractor.py -b Netgear -sql 127.0.0.1 -np -nk "$ZIP_FILE" images
+
+./scripts/getArch.sh ./images/1.tar.gz
+./scripts/tar2db.py -i 1 -f ./images/1.tar.gz
+
+# FIXME: Why does the following command return error status?
+set +e
+echo "firmadyne" | sudo -SE ./scripts/makeImage.sh 1
+set -e
+
+echo "Detecting network configuration"
+./scripts/inferNetwork.sh 1
+
+echo "Booting..."
+./scratch/1/run.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+set -x
+
+# Install dependencies
+sudo apt-get install -y busybox-static fakeroot git dmsetup kpartx netcat-openbsd nmap python-psycopg2 python3-psycopg2 snmp uml-utilities util-linux vlan postgresql wget qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils vim unzip
+
+# Move to firmadyne dir
+FIRMADYNE_INSTALL_DIR=/firmadyne
+mkdir $FIRMADYNE_INSTALL_DIR
+pushd $FIRMADYNE_INSTALL_DIR
+
+# Clone repos
+git clone https://github.com/devttys0/binwalk.git
+git clone --recursive https://github.com/firmadyne/firmadyne.git
+
+# Set up binwalk
+pushd binwalk
+sudo ./deps.sh --yes
+sudo python3 ./setup.py install
+popd
+
+# Install additional deps
+sudo pip3 install git+https://github.com/ahupp/python-magic
+sudo pip3 install git+https://github.com/sviehb/jefferson
+
+# Set up database
+sudo service postgresql start
+sudo -u postgres createuser firmadyne
+sudo -u postgres createdb -O firmadyne firmware
+sudo -u postgres psql -d firmware < ./firmadyne/database/schema
+echo "ALTER USER firmadyne PASSWORD 'firmadyne'" | sudo -u postgres psql
+
+# Set up firmadyne
+pushd firmadyne
+./download.sh
+
+# Set FIRMWARE_DIR in firmadyne.config
+mv firmadyne.config firmadyne.config.orig
+echo -e '#!/bin/sh' "\nFIRMWARE_DIR=$(pwd)/" > firmadyne.config
+cat firmadyne.config.orig >> firmadyne.config
+
+# Make sure firmadyne user owns this dir
+sudo chown -R firmadyne:firmadyne $FIRMADYNE_INSTALL_DIR

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+set -x
+
+export PGPASSWORD=firmadyne
+export USER=firmadyne
+
+# Start database
+echo "firmadyne" | sudo -S service postgresql start
+echo "Waiting for DB to start..."
+sleep 5
+
+exec "$@"


### PR DESCRIPTION
This patch adds a Dockerfile, along with a setup.sh script to install
necessary dependencies. An example_analysis.sh script is included which
demonstrates how to run an analysis from within the container.

After dockerization, the tedium of setting up and running firmadyne 
is reduced to two simple commands, and makes things much more
easily reproducible:

    docker build -t firmadyne .
    docker run --privileged --rm -v $PWD:/work -w /work -it --net=host firmadyne ./example_analysis.sh

A browser on the local machine can then be used to connect to the admin interface of the emulated device at http://192.168.0.100.