### PR TITLE
Fix Id conflict bug

### DIFF
--- a/scripts/makeNetwork.py
+++ b/scripts/makeNetwork.py
@@ -152,17 +152,23 @@ def qemuArchNetworkConfig(i, arch, n):
 def qemuNetworkConfig(arch, network):
     output = []
     assigned = []
-    for i in range(0, 4):
+
+    # Fix Id conflict bug
+    flag = 0
+    for k in range(0, 4):
         for j, n in enumerate(network):
             # need to connect the jth emulated network interface to the corresponding host interface
-            if i == ifaceNo(n[1]):
+            if k == ifaceNo(n[1]):
                 output.append(qemuArchNetworkConfig(j, arch, n))
                 assigned.append(n)
+                flag = j
                 break
 
-        # otherwise, put placeholder socket connection
-        if len(output) <= i:
-            output.append(qemuArchNetworkConfig(i, arch, None))
+    for i in range(0, 4):
+        if i != flag:
+            # otherwise, put placeholder socket connection
+            if len(output) <= i:
+                output.append(qemuArchNetworkConfig(i, arch, None))
 
     # find unassigned interfaces
     for j, n in enumerate(network):


### PR DESCRIPTION
File `scripts/makeNetwork.py` sometimes has the problem of id conflict after `-netdev`. I think it has some logic errors. It iterates through 0 to 4 and creates some instructions to add to the output. Sometimes it is necessary to connect the jth emulated network interface. But the value of j is not i, sometimes it is smaller than i, so two identical id values will be generated in output. 

A detailed discovery process for this issue has been created: [firmadyne - issues#130](https://github.com/firmadyne/firmadyne/issues/130)