### PR TITLE
Revert "Bugfix in fixImage.sh"

### DIFF
--- a/scripts/fixImage.sh
+++ b/scripts/fixImage.sh
@@ -15,34 +15,34 @@ resolve_link() {
 backup_file(){
     if [ -f "$1" ]; then
         echo "Backing up $1 to ${1}.bak"
-        $BUSYBOX cp "$1" "${1}.bak"
+        cp "$1" "${1}.bak"
     fi
 }
 
 rename_file(){
     if [ -f "$1" ]; then
         echo "Renaming $1 to ${1}.bak"
-        $BUSYBOX mv "$1" "${1}.bak"
+        mv "$1" "${1}.bak"
     fi
 }
 
 remove_file(){
     if [ -f "$1" ]; then
         echo "Removing $1"
-        $BUSYBOX rm -f "$1"
+        rm -f "$1"
     fi
 }
 # make /etc and add some essential files
-$BUSYBOX mkdir -p "$(resolve_link /etc)"
+mkdir -p "$(resolve_link /etc)"
 if [ ! -s /etc/TZ ]; then
     echo "Creating /etc/TZ!"
-    $BUSYBOX mkdir -p "$(dirname $(resolve_link /etc/TZ))"
+    mkdir -p "$(dirname $(resolve_link /etc/TZ))"
     echo "EST5EDT" > "$(resolve_link /etc/TZ)"
 fi
 
 if [ ! -s /etc/hosts ]; then
     echo "Creating /etc/hosts!"
-    $BUSYBOX mkdir -p "$(dirname $(resolve_link /etc/hosts))"
+    mkdir -p "$(dirname $(resolve_link /etc/hosts))"
     echo "127.0.0.1 localhost" > "$(resolve_link /etc/hosts)"
 fi
 
@@ -50,7 +50,7 @@ PASSWD=$(resolve_link /etc/passwd)
 SHADOW=$(resolve_link /etc/shadow)
 if [ ! -s "$PASSWD" ]; then
     echo "Creating $PASSWD!"
-    $BUSYBOX $BUSYBOX mkdir -p "$(dirname $PASSWD)"
+    mkdir -p "$(dirname $PASSWD)"
     echo "root::0:0:root:/root:/bin/sh" > "$PASSWD"
 else
     backup_file $PASSWD
@@ -58,7 +58,7 @@ else
     if ! $BUSYBOX grep -sq "^root:" $PASSWD ; then
         echo "No root user found, creating root user with shell '/bin/sh'"
         echo "root::0:0:root:/root:/bin/sh" > "$PASSWD"
-        $BUSYBOX [ ! -d '/root' ] && $BUSYBOX $BUSYBOX mkdir /root
+        $BUSYBOX [ ! -d '/root' ] && $BUSYBOX mkdir /root
     fi
 
     if [ -z "$($BUSYBOX grep -Es '^root:' $PASSWD |$BUSYBOX grep -Es ':/bin/sh$')" ] ; then
@@ -75,99 +75,99 @@ fi
 
 # make /dev and add default device nodes if current /dev does not have greater
 # than 5 device nodes
-$BUSYBOX mkdir -p "$(resolve_link /dev)"
+mkdir -p "$(resolve_link /dev)"
 FILECOUNT="$($BUSYBOX find ${WORKDIR}/dev -maxdepth 1 -type b -o -type c -print | $BUSYBOX wc -l)"
 if [ $FILECOUNT -lt "5" ]; then
     echo "Warning: Recreating device nodes!"
 
-    $BUSYBOX mknod -m 660 /dev/mem c 1 1
-    $BUSYBOX mknod -m 640 /dev/kmem c 1 2
-    $BUSYBOX mknod -m 666 /dev/null c 1 3
-    $BUSYBOX mknod -m 666 /dev/zero c 1 5
-    $BUSYBOX mknod -m 444 /dev/random c 1 8
-    $BUSYBOX mknod -m 444 /dev/urandom c 1 9
-    $BUSYBOX mknod -m 666 /dev/armem c 1 13
+    mknod -m 660 /dev/mem c 1 1
+    mknod -m 640 /dev/kmem c 1 2
+    mknod -m 666 /dev/null c 1 3
+    mknod -m 666 /dev/zero c 1 5
+    mknod -m 444 /dev/random c 1 8
+    mknod -m 444 /dev/urandom c 1 9
+    mknod -m 666 /dev/armem c 1 13
 
-    $BUSYBOX mknod -m 666 /dev/tty c 5 0
-    $BUSYBOX mknod -m 622 /dev/console c 5 1
-    $BUSYBOX mknod -m 666 /dev/ptmx c 5 2
+    mknod -m 666 /dev/tty c 5 0
+    mknod -m 622 /dev/console c 5 1
+    mknod -m 666 /dev/ptmx c 5 2
 
-    $BUSYBOX mknod -m 622 /dev/tty0 c 4 0
-    $BUSYBOX mknod -m 660 /dev/ttyS0 c 4 64
-    $BUSYBOX mknod -m 660 /dev/ttyS1 c 4 65
-    $BUSYBOX mknod -m 660 /dev/ttyS2 c 4 66
-    $BUSYBOX mknod -m 660 /dev/ttyS3 c 4 67
+    mknod -m 622 /dev/tty0 c 4 0
+    mknod -m 660 /dev/ttyS0 c 4 64
+    mknod -m 660 /dev/ttyS1 c 4 65
+    mknod -m 660 /dev/ttyS2 c 4 66
+    mknod -m 660 /dev/ttyS3 c 4 67
 
-    $BUSYBOX mknod -m 644 /dev/adsl0 c 100 0
-    $BUSYBOX mknod -m 644 /dev/ppp c 108 0
-    $BUSYBOX mknod -m 666 /dev/hidraw0 c 251 0
+    mknod -m 644 /dev/adsl0 c 100 0
+    mknod -m 644 /dev/ppp c 108 0
+    mknod -m 666 /dev/hidraw0 c 251 0
 
-    $BUSYBOX mkdir -p /dev/mtd
-    $BUSYBOX mknod -m 644 /dev/mtd/0 c 90 0
-    $BUSYBOX mknod -m 644 /dev/mtd/1 c 90 2
-    $BUSYBOX mknod -m 644 /dev/mtd/2 c 90 4
-    $BUSYBOX mknod -m 644 /dev/mtd/3 c 90 6
-    $BUSYBOX mknod -m 644 /dev/mtd/4 c 90 8
-    $BUSYBOX mknod -m 644 /dev/mtd/5 c 90 10
-    $BUSYBOX mknod -m 644 /dev/mtd/6 c 90 12
-    $BUSYBOX mknod -m 644 /dev/mtd/7 c 90 14
-    $BUSYBOX mknod -m 644 /dev/mtd/8 c 90 16
-    $BUSYBOX mknod -m 644 /dev/mtd/9 c 90 18
-    $BUSYBOX mknod -m 644 /dev/mtd/10 c 90 20
+    mkdir -p /dev/mtd
+    mknod -m 644 /dev/mtd/0 c 90 0
+    mknod -m 644 /dev/mtd/1 c 90 2
+    mknod -m 644 /dev/mtd/2 c 90 4
+    mknod -m 644 /dev/mtd/3 c 90 6
+    mknod -m 644 /dev/mtd/4 c 90 8
+    mknod -m 644 /dev/mtd/5 c 90 10
+    mknod -m 644 /dev/mtd/6 c 90 12
+    mknod -m 644 /dev/mtd/7 c 90 14
+    mknod -m 644 /dev/mtd/8 c 90 16
+    mknod -m 644 /dev/mtd/9 c 90 18
+    mknod -m 644 /dev/mtd/10 c 90 20
 
-    $BUSYBOX mknod -m 644 /dev/mtd0 c 90 0
-    $BUSYBOX mknod -m 644 /dev/mtdr0 c 90 1
-    $BUSYBOX mknod -m 644 /dev/mtd1 c 90 2
-    $BUSYBOX mknod -m 644 /dev/mtdr1 c 90 3
-    $BUSYBOX mknod -m 644 /dev/mtd2 c 90 4
-    $BUSYBOX mknod -m 644 /dev/mtdr2 c 90 5
-    $BUSYBOX mknod -m 644 /dev/mtd3 c 90 6
-    $BUSYBOX mknod -m 644 /dev/mtdr3 c 90 7
-    $BUSYBOX mknod -m 644 /dev/mtd4 c 90 8
-    $BUSYBOX mknod -m 644 /dev/mtdr4 c 90 9
-    $BUSYBOX mknod -m 644 /dev/mtd5 c 90 10
-    $BUSYBOX mknod -m 644 /dev/mtdr5 c 90 11
-    $BUSYBOX mknod -m 644 /dev/mtd6 c 90 12
-    $BUSYBOX mknod -m 644 /dev/mtdr6 c 90 13
-    $BUSYBOX mknod -m 644 /dev/mtd7 c 90 14
-    $BUSYBOX mknod -m 644 /dev/mtdr7 c 90 15
-    $BUSYBOX mknod -m 644 /dev/mtd8 c 90 16
-    $BUSYBOX mknod -m 644 /dev/mtdr8 c 90 17
-    $BUSYBOX mknod -m 644 /dev/mtd9 c 90 18
-    $BUSYBOX mknod -m 644 /dev/mtdr9 c 90 19
-    $BUSYBOX mknod -m 644 /dev/mtd10 c 90 20
-    $BUSYBOX mknod -m 644 /dev/mtdr10 c 90 21
+    mknod -m 644 /dev/mtd0 c 90 0
+    mknod -m 644 /dev/mtdr0 c 90 1
+    mknod -m 644 /dev/mtd1 c 90 2
+    mknod -m 644 /dev/mtdr1 c 90 3
+    mknod -m 644 /dev/mtd2 c 90 4
+    mknod -m 644 /dev/mtdr2 c 90 5
+    mknod -m 644 /dev/mtd3 c 90 6
+    mknod -m 644 /dev/mtdr3 c 90 7
+    mknod -m 644 /dev/mtd4 c 90 8
+    mknod -m 644 /dev/mtdr4 c 90 9
+    mknod -m 644 /dev/mtd5 c 90 10
+    mknod -m 644 /dev/mtdr5 c 90 11
+    mknod -m 644 /dev/mtd6 c 90 12
+    mknod -m 644 /dev/mtdr6 c 90 13
+    mknod -m 644 /dev/mtd7 c 90 14
+    mknod -m 644 /dev/mtdr7 c 90 15
+    mknod -m 644 /dev/mtd8 c 90 16
+    mknod -m 644 /dev/mtdr8 c 90 17
+    mknod -m 644 /dev/mtd9 c 90 18
+    mknod -m 644 /dev/mtdr9 c 90 19
+    mknod -m 644 /dev/mtd10 c 90 20
+    mknod -m 644 /dev/mtdr10 c 90 21
 
-    $BUSYBOX mkdir -p /dev/mtdblock
-    $BUSYBOX mknod -m 644 /dev/mtdblock/0 b 31 0
-    $BUSYBOX mknod -m 644 /dev/mtdblock/1 b 31 1
-    $BUSYBOX mknod -m 644 /dev/mtdblock/2 b 31 2
-    $BUSYBOX mknod -m 644 /dev/mtdblock/3 b 31 3
-    $BUSYBOX mknod -m 644 /dev/mtdblock/4 b 31 4
-    $BUSYBOX mknod -m 644 /dev/mtdblock/5 b 31 5
-    $BUSYBOX mknod -m 644 /dev/mtdblock/6 b 31 6
-    $BUSYBOX mknod -m 644 /dev/mtdblock/7 b 31 7
-    $BUSYBOX mknod -m 644 /dev/mtdblock/8 b 31 8
-    $BUSYBOX mknod -m 644 /dev/mtdblock/9 b 31 9
-    $BUSYBOX mknod -m 644 /dev/mtdblock/10 b 31 10
+    mkdir -p /dev/mtdblock
+    mknod -m 644 /dev/mtdblock/0 b 31 0
+    mknod -m 644 /dev/mtdblock/1 b 31 1
+    mknod -m 644 /dev/mtdblock/2 b 31 2
+    mknod -m 644 /dev/mtdblock/3 b 31 3
+    mknod -m 644 /dev/mtdblock/4 b 31 4
+    mknod -m 644 /dev/mtdblock/5 b 31 5
+    mknod -m 644 /dev/mtdblock/6 b 31 6
+    mknod -m 644 /dev/mtdblock/7 b 31 7
+    mknod -m 644 /dev/mtdblock/8 b 31 8
+    mknod -m 644 /dev/mtdblock/9 b 31 9
+    mknod -m 644 /dev/mtdblock/10 b 31 10
 
-    $BUSYBOX mknod -m 644 /dev/mtdblock0 b 31 0
-    $BUSYBOX mknod -m 644 /dev/mtdblock1 b 31 1
-    $BUSYBOX mknod -m 644 /dev/mtdblock2 b 31 2
-    $BUSYBOX mknod -m 644 /dev/mtdblock3 b 31 3
-    $BUSYBOX mknod -m 644 /dev/mtdblock4 b 31 4
-    $BUSYBOX mknod -m 644 /dev/mtdblock5 b 31 5
-    $BUSYBOX mknod -m 644 /dev/mtdblock6 b 31 6
-    $BUSYBOX mknod -m 644 /dev/mtdblock7 b 31 7
-    $BUSYBOX mknod -m 644 /dev/mtdblock8 b 31 8
-    $BUSYBOX mknod -m 644 /dev/mtdblock9 b 31 9
-    $BUSYBOX mknod -m 644 /dev/mtdblock10 b 31 10
+    mknod -m 644 /dev/mtdblock0 b 31 0
+    mknod -m 644 /dev/mtdblock1 b 31 1
+    mknod -m 644 /dev/mtdblock2 b 31 2
+    mknod -m 644 /dev/mtdblock3 b 31 3
+    mknod -m 644 /dev/mtdblock4 b 31 4
+    mknod -m 644 /dev/mtdblock5 b 31 5
+    mknod -m 644 /dev/mtdblock6 b 31 6
+    mknod -m 644 /dev/mtdblock7 b 31 7
+    mknod -m 644 /dev/mtdblock8 b 31 8
+    mknod -m 644 /dev/mtdblock9 b 31 9
+    mknod -m 644 /dev/mtdblock10 b 31 10
 
-    $BUSYBOX mkdir -p /dev/tts
-    $BUSYBOX mknod -m 660 /dev/tts/0 c 4 64
-    $BUSYBOX mknod -m 660 /dev/tts/1 c 4 65
-    $BUSYBOX mknod -m 660 /dev/tts/2 c 4 66
-    $BUSYBOX mknod -m 660 /dev/tts/3 c 4 67
+    mkdir -p /dev/tts
+    mknod -m 660 /dev/tts/0 c 4 64
+    mknod -m 660 /dev/tts/1 c 4 65
+    mknod -m 660 /dev/tts/2 c 4 66
+    mknod -m 660 /dev/tts/3 c 4 67
 fi
 
 # create a gpio file required for linksys to make the watchdog happy
@@ -175,7 +175,7 @@ if ($BUSYBOX grep -sq "/dev/gpio/in" /bin/gpio) ||
   ($BUSYBOX grep -sq "/dev/gpio/in" /usr/lib/libcm.so) ||
   ($BUSYBOX grep -sq "/dev/gpio/in" /usr/lib/libshared.so); then
     echo "Creating /dev/gpio/in!"
-    $BUSYBOX mkdir -p /dev/gpio
+    mkdir -p /dev/gpio
     echo -ne "\xff\xff\xff\xff" > /dev/gpio/in
 fi
 


### PR DESCRIPTION
Reverts firmadyne/firmadyne#165

Sorry that I have different view. Since @AndrewFasano mentioned that he experienced `Exec format error` under busybox shell for `mv` but not `cp` and `rm` . I really can't think of any scenario besides corrupted busybox. 

@AndrewFasano
Would you let us know more about the firmware file you are analyzing and steps to produce such error? Which linux distro and busybox are you using? 

`
$ sudo -SE ./scripts/makeImage.sh 1
...
Unlocking and blanking default root password. (*May not work since some routers reset the password back to default when booting)
Renaming /etc/securetty to /etc/securetty.bak
/fixImage.sh: line 218: mv: Exec format error
`