### PR TITLE
fix for python3.x in runExploits.py

### DIFF
--- a/analyses/runExploits.py
+++ b/analyses/runExploits.py
@@ -175,7 +175,7 @@ def main():
     for k, v in opts:
         if k == '-e':
             if v == 'x':
-                exploits = METASPLOIT_EXPLOITS.keys() + SHELL_EXPLOITS.keys()
+                exploits = list(METASPLOIT_EXPLOITS.keys()) + list(SHELL_EXPLOITS.keys())
             else:
                 exploits = [int(x) for x in v.split(',')]
         if k == '-t':


### PR DESCRIPTION
In Python 3.x, dict.keys doesn't return a list, but instead a view object, dict_keys

so we need to convert it to a list using list() to solve `TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'` when running with python 3.x