### PR TITLE
Ensure tar2db.py runs as python3

### DIFF
--- a/scripts/tar2db.py
+++ b/scripts/tar2db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import tarfile
 import getopt


### PR DESCRIPTION
This is a simple change, but it fixes `example_analyis.sh` in the Firmadyne docker container. Since the container is based on Ubuntu 14.04, `python` will run python2, not python3. But `setup.sh` installs `psycopg2` for python3 so `example_analysis.sh` leads to `tar2db.py` running in python2 in the container where you then get dependency errors.

Based off the issues I've run into with the container, it seems like it's not used too often? But if there's interest I could probably submit a PR in the future to bump it up to a newer version of Ubuntu and maybe even add some GitHub-actions CI to ensure it runs. Let me know if that's something you'd want.