### PR TITLE
Use grep -F instead of fgrep

### DIFF
--- a/scripts/getArch.sh
+++ b/scripts/getArch.sh
@@ -65,7 +65,7 @@ set -e
 
 for TARGET in ${FILES}
 do
-    SKIP=$(echo "${TARGET}" | fgrep -o / | wc -l)
+    SKIP=$(echo "${TARGET}" | grep -F -o / | wc -l)
     tar -xf "${INFILE}" -C "/tmp/${IID}/" --strip-components=${SKIP} ${TARGET}
     TARGETLOC="/tmp/$IID/${TARGET##*/}"
 


### PR DESCRIPTION
This will prevent an issue on newer distros replacing fgrep with a wrapper writing a warning.